### PR TITLE
refactor: define sdkerrors

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -309,7 +309,7 @@ func overwriteFlagDefaults(c *cobra.Command, defaults map[string]string) {
 	set := func(s *pflag.FlagSet, key, val string) {
 		if f := s.Lookup(key); f != nil {
 			f.DefValue = val
-			f.Value.Set(val) // nolint
+			f.Value.Set(val) //nolint
 		}
 	}
 	for key, val := range defaults {

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -1,0 +1,143 @@
+package errors
+
+import sdkerrors "cosmossdk.io/errors"
+
+// Codespace is the codespace for all errors defined in this package
+const Codespace = "ignite-modules"
+
+var (
+	// ErrTxDecode is returned if we cannot parse a transaction
+	ErrTxDecode = sdkerrors.Register(Codespace, 2, "tx parse error")
+
+	// ErrInvalidSequence is used the sequence number (nonce) is incorrect
+	// for the signature
+	ErrInvalidSequence = sdkerrors.Register(Codespace, 3, "invalid sequence")
+
+	// ErrUnauthorized is used whenever a request without sufficient
+	// authorization is handled.
+	ErrUnauthorized = sdkerrors.Register(Codespace, 4, "unauthorized")
+
+	// ErrInsufficientFunds is used when the account cannot pay requested amount.
+	ErrInsufficientFunds = sdkerrors.Register(Codespace, 5, "insufficient funds")
+
+	// ErrUnknownRequest to doc
+	ErrUnknownRequest = sdkerrors.Register(Codespace, 6, "unknown request")
+
+	// ErrInvalidAddress to doc
+	ErrInvalidAddress = sdkerrors.Register(Codespace, 7, "invalid address")
+
+	// ErrInvalidPubKey to doc
+	ErrInvalidPubKey = sdkerrors.Register(Codespace, 8, "invalid pubkey")
+
+	// ErrUnknownAddress to doc
+	ErrUnknownAddress = sdkerrors.Register(Codespace, 9, "unknown address")
+
+	// ErrInvalidCoins to doc
+	ErrInvalidCoins = sdkerrors.Register(Codespace, 10, "invalid coins")
+
+	// ErrOutOfGas to doc
+	ErrOutOfGas = sdkerrors.Register(Codespace, 11, "out of gas")
+
+	// ErrMemoTooLarge to doc
+	ErrMemoTooLarge = sdkerrors.Register(Codespace, 12, "memo too large")
+
+	// ErrInsufficientFee to doc
+	ErrInsufficientFee = sdkerrors.Register(Codespace, 13, "insufficient fee")
+
+	// ErrTooManySignatures to doc
+	ErrTooManySignatures = sdkerrors.Register(Codespace, 14, "maximum number of signatures exceeded")
+
+	// ErrNoSignatures to doc
+	ErrNoSignatures = sdkerrors.Register(Codespace, 15, "no signatures supplied")
+
+	// ErrJSONMarshal defines an ABCI typed JSON marshalling error
+	ErrJSONMarshal = sdkerrors.Register(Codespace, 16, "failed to marshal JSON bytes")
+
+	// ErrJSONUnmarshal defines an ABCI typed JSON unmarshalling error
+	ErrJSONUnmarshal = sdkerrors.Register(Codespace, 17, "failed to unmarshal JSON bytes")
+
+	// ErrInvalidRequest defines an ABCI typed error where the request contains
+	// invalid data.
+	ErrInvalidRequest = sdkerrors.Register(Codespace, 18, "invalid request")
+
+	// ErrTxInMempoolCache defines an ABCI typed error where a tx already exists
+	// in the mempool.
+	ErrTxInMempoolCache = sdkerrors.Register(Codespace, 19, "tx already in mempool")
+
+	// ErrMempoolIsFull defines an ABCI typed error where the mempool is full.
+	ErrMempoolIsFull = sdkerrors.Register(Codespace, 20, "mempool is full")
+
+	// ErrTxTooLarge defines an ABCI typed error where tx is too large.
+	ErrTxTooLarge = sdkerrors.Register(Codespace, 21, "tx too large")
+
+	// ErrKeyNotFound defines an error when the key doesn't exist
+	ErrKeyNotFound = sdkerrors.Register(Codespace, 22, "key not found")
+
+	// ErrWrongPassword defines an error when the key password is invalid.
+	ErrWrongPassword = sdkerrors.Register(Codespace, 23, "invalid account password")
+
+	// ErrorInvalidSigner defines an error when the tx intended signer does not match the given signer.
+	ErrorInvalidSigner = sdkerrors.Register(Codespace, 24, "tx intended signer does not match the given signer")
+
+	// ErrorInvalidGasAdjustment defines an error for an invalid gas adjustment
+	ErrorInvalidGasAdjustment = sdkerrors.Register(Codespace, 25, "invalid gas adjustment")
+
+	// ErrInvalidHeight defines an error for an invalid height
+	ErrInvalidHeight = sdkerrors.Register(Codespace, 26, "invalid height")
+
+	// ErrInvalidVersion defines a general error for an invalid version
+	ErrInvalidVersion = sdkerrors.Register(Codespace, 27, "invalid version")
+
+	// ErrInvalidChainID defines an error when the chain-id is invalid.
+	ErrInvalidChainID = sdkerrors.Register(Codespace, 28, "invalid chain-id")
+
+	// ErrInvalidType defines an error an invalid type.
+	ErrInvalidType = sdkerrors.Register(Codespace, 29, "invalid type")
+
+	// ErrTxTimeoutHeight defines an error for when a tx is rejected out due to an
+	// explicitly set timeout height.
+	ErrTxTimeoutHeight = sdkerrors.Register(Codespace, 30, "tx timeout height")
+
+	// ErrUnknownExtensionOptions defines an error for unknown extension options.
+	ErrUnknownExtensionOptions = sdkerrors.Register(Codespace, 31, "unknown extension options")
+
+	// ErrWrongSequence defines an error where the account sequence defined in
+	// the signer info doesn't match the account's actual sequence number.
+	ErrWrongSequence = sdkerrors.Register(Codespace, 32, "incorrect account sequence")
+
+	// ErrPackAny defines an error when packing a protobuf message to Any fails.
+	ErrPackAny = sdkerrors.Register(Codespace, 33, "failed packing protobuf message to Any")
+
+	// ErrUnpackAny defines an error when unpacking a protobuf message from Any fails.
+	ErrUnpackAny = sdkerrors.Register(Codespace, 34, "failed unpacking protobuf message from Any")
+
+	// ErrLogic defines an internal logic error, e.g. an invariant or assertion
+	// that is violated. It is a programmer error, not a user-facing error.
+	ErrLogic = sdkerrors.Register(Codespace, 35, "internal logic error")
+
+	// ErrConflict defines a conflict error, e.g. when two goroutines try to access
+	// the same resource and one of them fails.
+	ErrConflict = sdkerrors.Register(Codespace, 36, "conflict")
+
+	// ErrNotSupported is returned when we call a branch of a code which is currently not
+	// supported.
+	ErrNotSupported = sdkerrors.Register(Codespace, 37, "feature not supported")
+
+	// ErrNotFound defines an error when requested entity doesn't exist in the state.
+	ErrNotFound = sdkerrors.Register(Codespace, 38, "not found")
+
+	// ErrIO should be used to wrap internal errors caused by external operation.
+	// Examples: not DB domain error, file writing etc...
+	ErrIO = sdkerrors.Register(Codespace, 39, "Internal IO error")
+
+	// ErrAppConfig defines an error occurred if min-gas-prices field in BaseConfig is empty.
+	ErrAppConfig = sdkerrors.Register(Codespace, 40, "error in app.toml")
+
+	// ErrInvalidGasLimit defines an error when an invalid GasWanted value is
+	// supplied.
+	ErrInvalidGasLimit = sdkerrors.Register(Codespace, 41, "invalid gas limit")
+
+	// ErrPanic is only set when we recover from a panic, so we know to
+	// redact potentially sensitive system info
+	ErrPanic = sdkerrors.ErrPanic
+)

--- a/x/claim/keeper/airdrop_supply.go
+++ b/x/claim/keeper/airdrop_supply.go
@@ -4,7 +4,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	criterrors "github.com/ignite/modules/errors"
+	"github.com/ignite/modules/errors"
 	"github.com/ignite/modules/x/claim/types"
 )
 
@@ -46,13 +46,13 @@ func (k Keeper) InitializeAirdropSupply(ctx sdk.Context, airdropSupply sdk.Coin)
 	// if the module has an existing balance, we burn the entire balance
 	if moduleBalance.IsPositive() {
 		if err := k.bankKeeper.BurnCoins(ctx, types.ModuleName, sdk.NewCoins(moduleBalance)); err != nil {
-			return criterrors.Criticalf("can't burn module balance %s", err.Error())
+			return errors.Criticalf("can't burn module balance %s", err.Error())
 		}
 	}
 
 	// set the module balance with the airdrop supply
 	if err := k.bankKeeper.MintCoins(ctx, types.ModuleName, sdk.NewCoins(airdropSupply)); err != nil {
-		return criterrors.Criticalf("can't mint airdrop suply into module balance %s", err.Error())
+		return errors.Criticalf("can't mint airdrop suply into module balance %s", err.Error())
 	}
 
 	k.SetAirdropSupply(ctx, airdropSupply)

--- a/x/claim/keeper/grpc_mission.go
+++ b/x/claim/keeper/grpc_mission.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrortypes "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/cosmos-sdk/types/query"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"

--- a/x/claim/keeper/grpc_mission.go
+++ b/x/claim/keeper/grpc_mission.go
@@ -9,6 +9,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/ignite/modules/errors"
 	"github.com/ignite/modules/x/claim/types"
 )
 
@@ -47,7 +48,7 @@ func (k Keeper) Mission(c context.Context, req *types.QueryGetMissionRequest) (*
 	ctx := sdk.UnwrapSDKContext(c)
 	mission, found := k.GetMission(ctx, req.MissionID)
 	if !found {
-		return nil, sdkerrortypes.ErrKeyNotFound
+		return nil, errors.ErrKeyNotFound
 	}
 
 	return &types.QueryGetMissionResponse{Mission: mission}, nil

--- a/x/claim/keeper/grpc_mission_test.go
+++ b/x/claim/keeper/grpc_mission_test.go
@@ -9,6 +9,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/ignite/modules/errors"
 	testkeeper "github.com/ignite/modules/testutil/keeper"
 	"github.com/ignite/modules/testutil/nullify"
 	"github.com/ignite/modules/x/claim/types"
@@ -38,7 +39,7 @@ func TestMissionQuerySingle(t *testing.T) {
 		{
 			desc:    "KeyNotFound",
 			request: &types.QueryGetMissionRequest{MissionID: uint64(len(msgs))},
-			err:     sdkerrortypes.ErrKeyNotFound,
+			err:     errors.ErrKeyNotFound,
 		},
 		{
 			desc: "InvalidRequest",

--- a/x/claim/keeper/grpc_mission_test.go
+++ b/x/claim/keeper/grpc_mission_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrortypes "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/cosmos-sdk/types/query"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"

--- a/x/claim/keeper/mission.go
+++ b/x/claim/keeper/mission.go
@@ -7,7 +7,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	criterrors "github.com/ignite/modules/errors"
+	errors "github.com/ignite/modules/errors"
 	"github.com/ignite/modules/x/claim/types"
 )
 
@@ -105,16 +105,16 @@ func (k Keeper) CompleteMission(ctx sdk.Context, missionID uint64, address strin
 	// decrease airdrop supply
 	airdropSupply.Amount = airdropSupply.Amount.Sub(claimable.AmountOf(airdropSupply.Denom))
 	if airdropSupply.Amount.IsNegative() {
-		return criterrors.Critical("airdrop supply is lower than total claimable")
+		return errors.Critical("airdrop supply is lower than total claimable")
 	}
 
 	// send claimable to the user
 	claimer, err := sdk.AccAddressFromBech32(address)
 	if err != nil {
-		return criterrors.Criticalf("invalid claimer address %s", err.Error())
+		return errors.Criticalf("invalid claimer address %s", err.Error())
 	}
 	if err := k.bankKeeper.SendCoinsFromModuleToAccount(ctx, types.ModuleName, claimer, claimable); err != nil {
-		return criterrors.Criticalf("can't send claimable coins %s", err.Error())
+		return errors.Criticalf("can't send claimable coins %s", err.Error())
 	}
 
 	// update store

--- a/x/claim/module.go
+++ b/x/claim/module.go
@@ -76,7 +76,7 @@ func (AppModuleBasic) RegisterRESTRoutes(clientCtx client.Context, rtr *mux.Rout
 
 // RegisterGRPCGatewayRoutes registers the gRPC Gateway routes for the module.
 func (AppModuleBasic) RegisterGRPCGatewayRoutes(clientCtx client.Context, mux *runtime.ServeMux) {
-	types.RegisterQueryHandlerClient(context.Background(), mux, types.NewQueryClient(clientCtx)) // nolint
+	types.RegisterQueryHandlerClient(context.Background(), mux, types.NewQueryClient(clientCtx)) //nolint
 }
 
 // GetTxCmd returns the claim module's root tx command.

--- a/x/claim/types/msg_claim_initial.go
+++ b/x/claim/types/msg_claim_initial.go
@@ -3,7 +3,6 @@ package types
 import (
 	sdkerrors "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkerrortypes "github.com/cosmos/cosmos-sdk/types/errors"
 )
 
 const TypeMsgClaimInitial = "claim_initial"

--- a/x/claim/types/msg_claim_initial.go
+++ b/x/claim/types/msg_claim_initial.go
@@ -3,6 +3,8 @@ package types
 import (
 	sdkerrors "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/ignite/modules/errors"
 )
 
 const TypeMsgClaimInitial = "claim_initial"
@@ -39,7 +41,7 @@ func (msg *MsgClaimInitial) GetSignBytes() []byte {
 func (msg *MsgClaimInitial) ValidateBasic() error {
 	_, err := sdk.AccAddressFromBech32(msg.Claimer)
 	if err != nil {
-		return sdkerrors.Wrapf(sdkerrortypes.ErrInvalidAddress, "invalid claimer address (%s)", err)
+		return sdkerrors.Wrapf(errors.ErrInvalidAddress, "invalid claimer address (%s)", err)
 	}
 	return nil
 }

--- a/x/claim/types/msg_claim_initial_test.go
+++ b/x/claim/types/msg_claim_initial_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/ignite/modules/errors"
 	"github.com/ignite/modules/testutil/sample"
 	"github.com/ignite/modules/x/claim/types"
 )
@@ -20,7 +21,7 @@ func TestMsgClaimInitial_ValidateBasic(t *testing.T) {
 			msg: types.MsgClaimInitial{
 				Claimer: "invalid_address",
 			},
-			err: sdkerrortypes.ErrInvalidAddress,
+			err: errors.ErrInvalidAddress,
 		}, {
 			name: "should validate valid claimer address",
 			msg: types.MsgClaimInitial{

--- a/x/claim/types/msg_claim_initial_test.go
+++ b/x/claim/types/msg_claim_initial_test.go
@@ -3,7 +3,6 @@ package types_test
 import (
 	"testing"
 
-	sdkerrortypes "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ignite/modules/testutil/sample"

--- a/x/mint/module.go
+++ b/x/mint/module.go
@@ -67,7 +67,7 @@ func (AppModuleBasic) RegisterRESTRoutes(_ client.Context, _ *mux.Router) {
 
 // RegisterGRPCGatewayRoutes registers the gRPC Gateway routes for the mint module.
 func (AppModuleBasic) RegisterGRPCGatewayRoutes(clientCtx client.Context, mux *runtime.ServeMux) {
-	types.RegisterQueryHandlerClient(context.Background(), mux, types.NewQueryClient(clientCtx)) // nolint
+	types.RegisterQueryHandlerClient(context.Background(), mux, types.NewQueryClient(clientCtx)) //nolint
 }
 
 // GetTxCmd returns no root tx command for the mint module.


### PR DESCRIPTION
<!-- 🎉 Thank you for the PR!!! 🎉 -->

Our recent PR that moved to using `cosmossdk.io/errors` created a non-ideal split between the `sdkerrors` and `sdkerrortypes` packages.  Given the design decision of not including defined errors in the new `sdkerrors` package, it makes sense that we define errors.

This PR adds an `errors.go` file in our `errors` package that contains all of the cosmos sdk error types defined in the "ignite-modules" codespace.  This package could be used by other chains, or just used internally.

I think this is cleaner than the previous approach and also prepares us for the time when the old `types/errors` package is fully removed from the SDK.
