### PR TITLE
docs(`mint`): remove mention of ATOMs in comments

### DIFF
--- a/proto/mint/mint.proto
+++ b/proto/mint/mint.proto
@@ -79,7 +79,7 @@ message Params {
     (gogoproto.customtype) = "github.com/cosmos/cosmos-sdk/types.Dec",
     (cosmos_proto.scalar)  = "cosmos.Dec"
   ];
-  // goal of percent bonded atoms
+  // goal of percent bonded coins
   string goal_bonded = 5 [
     (gogoproto.nullable)   = false,
     (gogoproto.customtype) = "github.com/cosmos/cosmos-sdk/types.Dec",

--- a/x/mint/types/mint.pb.go
+++ b/x/mint/types/mint.pb.go
@@ -166,7 +166,7 @@ type Params struct {
 	InflationMax github_com_cosmos_cosmos_sdk_types.Dec `protobuf:"bytes,3,opt,name=inflation_max,json=inflationMax,proto3,customtype=github.com/cosmos/cosmos-sdk/types.Dec" json:"inflation_max"`
 	// minimum inflation rate
 	InflationMin github_com_cosmos_cosmos_sdk_types.Dec `protobuf:"bytes,4,opt,name=inflation_min,json=inflationMin,proto3,customtype=github.com/cosmos/cosmos-sdk/types.Dec" json:"inflation_min"`
-	// goal of percent bonded atoms
+	// goal of percent bonded coins
 	GoalBonded github_com_cosmos_cosmos_sdk_types.Dec `protobuf:"bytes,5,opt,name=goal_bonded,json=goalBonded,proto3,customtype=github.com/cosmos/cosmos-sdk/types.Dec" json:"goal_bonded"`
 	// expected blocks per year
 	BlocksPerYear uint64 `protobuf:"varint,6,opt,name=blocks_per_year,json=blocksPerYear,proto3" json:"blocks_per_year,omitempty"`

--- a/x/mint/types/minter_test.go
+++ b/x/mint/types/minter_test.go
@@ -20,7 +20,7 @@ func TestNextInflation(t *testing.T) {
 	tests := []struct {
 		bondedRatio, setInflation, expChange sdk.Dec
 	}{
-		// with 0% bonded atom supply the inflation should increase by InflationRateChange
+		// with 0% bonded coins supply the inflation should increase by InflationRateChange
 		{sdk.ZeroDec(), sdk.NewDecWithPrec(7, 2), params.InflationRateChange.Quo(blocksPerYr)},
 
 		// 100% bonded, starting at 20% inflation and being reduced

--- a/x/mint/types/minter_test.go
+++ b/x/mint/types/minter_test.go
@@ -20,7 +20,7 @@ func TestNextInflation(t *testing.T) {
 	tests := []struct {
 		bondedRatio, setInflation, expChange sdk.Dec
 	}{
-		// with 0% bonded coins supply the inflation should increase by InflationRateChange
+		// with 0% bonded coin supply the inflation should increase by InflationRateChange
 		{sdk.ZeroDec(), sdk.NewDecWithPrec(7, 2), params.InflationRateChange.Quo(blocksPerYr)},
 
 		// 100% bonded, starting at 20% inflation and being reduced


### PR DESCRIPTION
Replace atom occurences with "coins"