### PR TITLE
refactor(`mint`): cleanup module

### DIFF
--- a/x/mint/keeper/abci.go
+++ b/x/mint/keeper/abci.go
@@ -1,17 +1,14 @@
-package mint
+package keeper
 
 import (
-	"time"
-
 	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-
-	"github.com/ignite/modules/x/mint/keeper"
 	"github.com/ignite/modules/x/mint/types"
+	"time"
 )
 
 // BeginBlocker mints new coins for the previous block.
-func BeginBlocker(ctx sdk.Context, k keeper.Keeper) error {
+func (k Keeper) BeginBlocker(ctx sdk.Context) error {
 	defer telemetry.ModuleMeasureSince(types.ModuleName, time.Now(), telemetry.MetricKeyBeginBlocker)
 
 	// fetch stored minter & params

--- a/x/mint/keeper/abci.go
+++ b/x/mint/keeper/abci.go
@@ -1,10 +1,12 @@
 package keeper
 
 import (
+	"time"
+
 	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	"github.com/ignite/modules/x/mint/types"
-	"time"
 )
 
 // BeginBlocker mints new coins for the previous block.
@@ -24,17 +26,15 @@ func (k Keeper) BeginBlocker(ctx sdk.Context) error {
 
 	// mint coins, update supply
 	mintedCoin := minter.BlockProvision(params)
-	mintedCoins := sdk.NewCoins(mintedCoin)
-
-	err := k.MintCoins(ctx, mintedCoins)
+	err := k.MintCoin(ctx, mintedCoin)
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	// distribute minted coins according to the defined proportions
-	err = k.DistributeMintedCoins(ctx, mintedCoin)
+	err = k.DistributeMintedCoin(ctx, mintedCoin)
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	if mintedCoin.Amount.IsInt64() {

--- a/x/mint/keeper/abci_test.go
+++ b/x/mint/keeper/abci_test.go
@@ -4,5 +4,4 @@ import "testing"
 
 // TODO add test
 func TestBeginBlocker(t *testing.T) {
-
 }

--- a/x/mint/keeper/abci_test.go
+++ b/x/mint/keeper/abci_test.go
@@ -1,0 +1,8 @@
+package keeper_test
+
+import "testing"
+
+// TODO add test
+func TestBeginBlocker(t *testing.T) {
+
+}

--- a/x/mint/keeper/integration_test.go
+++ b/x/mint/keeper/integration_test.go
@@ -4,25 +4,10 @@ import (
 	"encoding/json"
 
 	"github.com/cosmos/cosmos-sdk/simapp"
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	abci "github.com/tendermint/tendermint/abci/types"
-	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
-
 	testapp "github.com/ignite/modules/app"
 	"github.com/ignite/modules/testutil"
-	"github.com/ignite/modules/x/mint/types"
+	abci "github.com/tendermint/tendermint/abci/types"
 )
-
-// returns context and an app with updated mint keeper
-func createTestApp(isCheckTx bool) (*testapp.App, sdk.Context) {
-	app := setup(isCheckTx)
-
-	ctx := app.BaseApp.NewContext(isCheckTx, tmproto.Header{})
-	app.MintKeeper.SetParams(ctx, types.DefaultParams())
-	app.MintKeeper.SetMinter(ctx, types.DefaultInitialMinter())
-
-	return app, ctx
-}
 
 func setup(isCheckTx bool) *testapp.App {
 	app, genesisState := testutil.GenApp(!isCheckTx, 5)

--- a/x/mint/keeper/integration_test.go
+++ b/x/mint/keeper/integration_test.go
@@ -4,9 +4,10 @@ import (
 	"encoding/json"
 
 	"github.com/cosmos/cosmos-sdk/simapp"
+	abci "github.com/tendermint/tendermint/abci/types"
+
 	testapp "github.com/ignite/modules/app"
 	"github.com/ignite/modules/testutil"
-	abci "github.com/tendermint/tendermint/abci/types"
 )
 
 func setup(isCheckTx bool) *testapp.App {

--- a/x/mint/keeper/keeper.go
+++ b/x/mint/keeper/keeper.go
@@ -99,15 +99,10 @@ func (k Keeper) BondedRatio(ctx sdk.Context) sdk.Dec {
 	return k.stakingKeeper.BondedRatio(ctx)
 }
 
-// MintCoins implements an alias call to the underlying supply keeper's
-// MintCoins to be used in BeginBlocker.
-func (k Keeper) MintCoins(ctx sdk.Context, newCoins sdk.Coins) error {
-	if newCoins.Empty() {
-		// skip as no coins need to be minted
-		return nil
-	}
-
-	return k.bankKeeper.MintCoins(ctx, types.ModuleName, newCoins)
+// MintCoin implements an alias call to the underlying supply keeper's
+// MintCoin to be used in BeginBlocker.
+func (k Keeper) MintCoin(ctx sdk.Context, coin sdk.Coin) error {
+	return k.bankKeeper.MintCoins(ctx, types.ModuleName, sdk.NewCoins(coin))
 }
 
 // AddCollectedFees implements an alias call to the underlying supply keeper's
@@ -123,7 +118,7 @@ func (k Keeper) GetProportions(ctx sdk.Context, mintedCoin sdk.Coin, ratio sdk.D
 
 // DistributeMintedCoins implements distribution of minted coins from mint
 // DistributeMintedCoins to be used in BeginBlocker.
-func (k Keeper) DistributeMintedCoins(ctx sdk.Context, mintedCoin sdk.Coin) error {
+func (k Keeper) DistributeMintedCoin(ctx sdk.Context, mintedCoin sdk.Coin) error {
 	params := k.GetParams(ctx)
 	proportions := params.DistributionProportions
 

--- a/x/mint/keeper/keeper.go
+++ b/x/mint/keeper/keeper.go
@@ -107,8 +107,8 @@ func (k Keeper) MintCoin(ctx sdk.Context, coin sdk.Coin) error {
 
 // AddCollectedFees implements an alias call to the underlying supply keeper's
 // AddCollectedFees to be used in BeginBlocker.
-func (k Keeper) AddCollectedFees(ctx sdk.Context, fees sdk.Coins) error {
-	return k.bankKeeper.SendCoinsFromModuleToModule(ctx, types.ModuleName, k.feeCollectorName, fees)
+func (k Keeper) AddCollectedFees(ctx sdk.Context, fee sdk.Coin) error {
+	return k.bankKeeper.SendCoinsFromModuleToModule(ctx, types.ModuleName, k.feeCollectorName, sdk.NewCoins(fee))
 }
 
 // GetProportions gets the balance of the `MintedDenom` from minted coins and returns coins according to the `AllocationRatio`.

--- a/x/mint/module.go
+++ b/x/mint/module.go
@@ -145,7 +145,7 @@ func (AppModule) ConsensusVersion() uint64 { return 1 }
 
 // BeginBlock returns the begin blocker for the mint module.
 func (am AppModule) BeginBlock(ctx sdk.Context, _ abci.RequestBeginBlock) {
-	if err := BeginBlocker(ctx, am.keeper); err != nil {
+	if err := am.keeper.BeginBlocker(ctx); err != nil {
 		ctx.Logger().Error(
 			fmt.Sprintf("error minting new coins: %s",
 				err.Error()),

--- a/x/mint/module.go
+++ b/x/mint/module.go
@@ -39,9 +39,7 @@ func (AppModuleBasic) Name() string {
 	return types.ModuleName
 }
 
-func (AppModuleBasic) RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
-	sdk.RegisterLegacyAminoCodec(cdc)
-}
+func (AppModuleBasic) RegisterLegacyAminoCodec(_ *codec.LegacyAmino) {}
 
 // RegisterInterfaces registers the module's interface types
 func (b AppModuleBasic) RegisterInterfaces(_ cdctypes.InterfaceRegistry) {}

--- a/x/mint/module_simulation.go
+++ b/x/mint/module_simulation.go
@@ -1,0 +1,39 @@
+package mint
+
+import (
+	"math/rand"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
+
+	"github.com/ignite/modules/x/mint/simulation"
+	"github.com/ignite/modules/x/mint/types"
+)
+
+// AppModuleSimulation functions
+
+// GenerateGenesisState creates a randomized GenState of the mint module.
+func (AppModule) GenerateGenesisState(simState *module.SimulationState) {
+	simulation.RandomizedGenState(simState)
+}
+
+// ProposalContents doesn't return any content functions for governance proposals.
+func (AppModule) ProposalContents(simState module.SimulationState) []simtypes.WeightedProposalContent {
+	return nil
+}
+
+// RandomizedParams creates randomized mint param changes for the simulator.
+func (AppModule) RandomizedParams(r *rand.Rand) []simtypes.ParamChange {
+	return simulation.ParamChanges(r)
+}
+
+// RegisterStoreDecoder registers a decoder for mint module's types.
+func (am AppModule) RegisterStoreDecoder(sdr sdk.StoreDecoderRegistry) {
+	sdr[types.StoreKey] = simulation.NewDecodeStore(am.cdc)
+}
+
+// WeightedOperations doesn't return any mint module operation.
+func (AppModule) WeightedOperations(_ module.SimulationState) []simtypes.WeightedOperation {
+	return nil
+}

--- a/x/mint/types/genesis.go
+++ b/x/mint/types/genesis.go
@@ -8,20 +8,20 @@ func NewGenesisState(minter Minter, params Params) *GenesisState {
 	}
 }
 
-// DefaultGenesisState creates a default GenesisState object
-func DefaultGenesisState() *GenesisState {
+// DefaultGenesis creates a default GenesisState object
+func DefaultGenesis() *GenesisState {
 	return &GenesisState{
 		Minter: DefaultInitialMinter(),
 		Params: DefaultParams(),
 	}
 }
 
-// ValidateGenesis validates the provided genesis state to ensure the
+// Validate validates the provided genesis state to ensure the
 // expected invariants holds.
-func ValidateGenesis(data GenesisState) error {
-	if err := data.Params.Validate(); err != nil {
+func (gs GenesisState) Validate() error {
+	if err := gs.Params.Validate(); err != nil {
 		return err
 	}
 
-	return ValidateMinter(data.Minter)
+	return ValidateMinter(gs.Minter)
 }

--- a/x/mint/types/keys.go
+++ b/x/mint/types/keys.go
@@ -12,9 +12,4 @@ const (
 
 	// QuerierRoute is the querier route for the minting store.
 	QuerierRoute = StoreKey
-
-	// Query endpoints supported by the minting querier
-	QueryParameters       = "parameters"
-	QueryInflation        = "inflation"
-	QueryAnnualProvisions = "annual_provisions"
 )


### PR DESCRIPTION
<!-- 🎉 Thank you for the PR!!! 🎉 -->

Basic cleanup and refactoring of the `mint` module.
- Make all minting functions take `sdk.Coin` args instead of some taking `sdk.Coins` and some taking `sdk.Coin`
- Remove some dead code
- move simulation code to `module_simulation.go`
- move `BeginBlocker` logic to `keeper` package so it can be tested in  a later PR
