### PR TITLE
fix: Import "gogoproto/gogo.proto" was not found

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -75,6 +75,7 @@ import (
 	upgradeclient "github.com/cosmos/cosmos-sdk/x/upgrade/client"
 	upgradekeeper "github.com/cosmos/cosmos-sdk/x/upgrade/keeper"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+	ibc "github.com/cosmos/ibc-go/v5/modules/core"
 	"github.com/spf13/cast"
 	abci "github.com/tendermint/tendermint/abci/types"
 	tmjson "github.com/tendermint/tendermint/libs/json"
@@ -125,6 +126,7 @@ var (
 	ModuleBasics = module.NewBasicManager(
 		auth.AppModuleBasic{},
 		authzmodule.AppModuleBasic{},
+		ibc.AppModuleBasic{},
 		genutil.AppModuleBasic{},
 		bank.AppModuleBasic{},
 		capability.AppModuleBasic{},


### PR DESCRIPTION
Closes #70

For Ignite to generate all proto files correctly, all modules should be registered in the `app.go`:

https://github.com/ignite/cli/blob/030bcd4a357f408c63d73b755625e0417f7545b7/ignite/pkg/cosmosanalysis/app/app.go#L86-L87