### PR TITLE
ci(coverage): test all go packages and remove the non-testable files from coverage

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -57,6 +57,7 @@ ignore:
   - "*.yml"
   - "*.yaml"
   - "*.pb.go"
+  - "*.pb.gw.go"
   - ".github/"
   - "app/"
   - "cmd/"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,10 +28,29 @@ jobs:
           go-version: 1.19
 
       - name: Run unit tests
-        run: go test -v -coverprofile=coverage.out -covermode=atomic ./...
+        run: |
+          go test -v -coverprofile=coverage.txt -covermode=atomic -coverpkg=./... $(go list ./...)
+
+      - name: filter non-testable files
+        run: |
+          excludelist="$(find ./ -type f -name '*.go' | xargs grep -l 'DONTCOVER')"
+          excludelist+=" $(find ./ -type f -name '*.pb.go')"
+          excludelist+=" $(find ./ -type f -name '*.pb.gw.go')"
+          excludelist+=" $(find ./app -type d)"
+          excludelist+=" $(find ./cmd -type d)"
+          excludelist+=" $(find ./proto -type d)"
+          excludelist+=" $(find ./testutil -type d)"
+          excludelist+=" $(find ./tools -type d)"
+          for filename in ${excludelist}; do
+            filename=${filename#".//"}
+            echo "Excluding ${filename} from coverage report..."
+            filename=$(echo "$filename" | sed 's/\//\\\//g')
+            sed -i.bak "/""$filename""/d" coverage.txt
+          done
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3.1.1
         with:
+          file: ./coverage.txt
           fail_ci_if_error: true
           verbose: true


### PR DESCRIPTION
## Description

If we have a package without test files (`_test.go`), the `go test` will exclude this package from the coverage. We should add the `-coverpkg=./...` to cover all packages. This PR also removes Go files autogenerated by the protobuf and, `app` and `cmd` packages from the coverage.