### PR TITLE
fix: correct spelling error in `airdrop_supply.go`

### DIFF
--- a/x/claim/keeper/airdrop_supply.go
+++ b/x/claim/keeper/airdrop_supply.go
@@ -52,7 +52,7 @@ func (k Keeper) InitializeAirdropSupply(ctx sdk.Context, airdropSupply sdk.Coin)
 
 	// set the module balance with the airdrop supply
 	if err := k.bankKeeper.MintCoins(ctx, types.ModuleName, sdk.NewCoins(airdropSupply)); err != nil {
-		return errors.Criticalf("can't mint airdrop suply into module balance %s", err.Error())
+		return errors.Criticalf("can't mint airdrop supply into module balance %s", err.Error())
 	}
 
 	k.SetAirdropSupply(ctx, airdropSupply)


### PR DESCRIPTION
Simple typo

<!-- 🎉 Thank you for the PR!!! 🎉 -->

Closes #<issue number>. _in case of a bug fix, this should point to a bug or any other related issue(s)_

### What does this PR do?

fix a simple spelling error





